### PR TITLE
Create testIdServer

### DIFF
--- a/src/client/testing/testController/common/utils.ts
+++ b/src/client/testing/testController/common/utils.ts
@@ -62,7 +62,7 @@ export function pythonTestAdapterRewriteEnabled(serviceContainer: IServiceContai
     return experiment.inExperimentSync(EnableTestAdapterRewrite.experiment);
 }
 
-export const startServer = (testIds: string): Promise<number> =>
+export const startTestIdServer = (testIds: string[]): Promise<number> =>
     new Promise((resolve, reject) => {
         const server = net.createServer((socket: net.Socket) => {
             // Convert the test_ids array to JSON

--- a/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
+++ b/src/client/testing/testController/pytest/pytestExecutionAdapter.ts
@@ -3,7 +3,6 @@
 
 import { TestRun, Uri } from 'vscode';
 import * as path from 'path';
-import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { traceError, traceInfo, traceLog, traceVerbose } from '../../../logging';

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -3,7 +3,6 @@
 
 import * as path from 'path';
 import { TestRun, Uri } from 'vscode';
-import * as net from 'net';
 import { IConfigurationService, ITestOutputChannel } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../constants';

--- a/src/client/testing/testController/unittest/testExecutionAdapter.ts
+++ b/src/client/testing/testController/unittest/testExecutionAdapter.ts
@@ -17,6 +17,7 @@ import {
     TestExecutionCommand,
 } from '../common/types';
 import { traceLog, traceError } from '../../../logging';
+import { startTestIdServer } from '../common/utils';
 
 /**
  * Wrapper Class for unittest test execution. This is where we call `runTestCommand`?
@@ -75,37 +76,11 @@ export class UnittestTestExecutionAdapter implements ITestExecutionAdapter {
 
         const deferred = createDeferred<ExecutionTestPayload>();
         this.promiseMap.set(uuid, deferred);
-        // create payload with testIds to send to run pytest script
-        const testData = JSON.stringify(testIds);
-        const headers = [`Content-Length: ${Buffer.byteLength(testData)}`, 'Content-Type: application/json'];
-        const payload = `${headers.join('\r\n')}\r\n\r\n${testData}`;
+
+        traceLog(`Running UNITTEST execution for the following test ids: ${testIds}`);
 
         let runTestIdsPort: string | undefined;
-        const startServer = (): Promise<number> =>
-            new Promise((resolve, reject) => {
-                const server = net.createServer((socket: net.Socket) => {
-                    socket.on('end', () => {
-                        traceLog('Client disconnected');
-                    });
-                });
-
-                server.listen(0, () => {
-                    const { port } = server.address() as net.AddressInfo;
-                    traceLog(`Server listening on port ${port}`);
-                    resolve(port);
-                });
-
-                server.on('error', (error: Error) => {
-                    reject(error);
-                });
-                server.on('connection', (socket: net.Socket) => {
-                    socket.write(payload);
-                    traceLog('payload sent', payload);
-                });
-            });
-
-        // Start the server and wait until it is listening
-        await startServer()
+        await startTestIdServer(testIds)
             .then((assignedPort) => {
                 traceLog(`Server started and listening on port ${assignedPort}`);
                 runTestIdsPort = assignedPort.toString();


### PR DESCRIPTION
Created a testIdServer to handle the starting up of the testIdServer for both unittest and pytest. This extracts the method to be in another file and easy to test.